### PR TITLE
Update Header test for localized name

### DIFF
--- a/src/components/Header.test.js
+++ b/src/components/Header.test.js
@@ -12,6 +12,6 @@ test('renders header title', () => {
       <Header />
     </I18nextProvider>
   );
-  const titleElement = screen.getByText(/Tu Nombre/i);
+  const titleElement = screen.getByText(i18n.t('header.name'));
   expect(titleElement).toBeInTheDocument();
 });


### PR DESCRIPTION
## Summary
- use i18n.t('header.name') in `Header.test.js`

## Testing
- `npm test --silent` *(fails: react-scripts not found)*