### PR TITLE
Update html lang attribute with i18n language

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,11 +21,15 @@ const LoadingFallback = () => {
 
 function App() {
   const { theme } = useContext(ThemeContext);
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   useEffect(() => {
     document.documentElement.setAttribute('data-theme', theme);
   }, [theme]);
+
+  useEffect(() => {
+    document.documentElement.lang = i18n.language;
+  }, [i18n.language]);
 
   return (
     <div className="App">

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,9 @@ import i18n from './i18n';
 import * as serviceWorkerRegistration from './serviceWorkerRegistration';
 import { BrowserRouter } from 'react-router-dom';
 
+// Ensure the HTML lang attribute matches the current i18n language
+document.documentElement.lang = i18n.language;
+
 const container = document.getElementById('root');
 const root = createRoot(container);
 


### PR DESCRIPTION
## Summary
- sync `<html lang>` with selected language

## Testing
- `npm test --silent -- -u --watchAll=false` *(fails: react-scripts not found)*