### PR TITLE
Update Desarrollo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ npm install
 2. Instala las dependencias con `npm ci`.
 3. Ejecuta `npm test` para correr las pruebas. Estas utilizan Jest a través de
    `react-scripts test`.
+4. Antes de crear un commit, ejecuta:
+
+   ```bash
+   npx prettier --write .
+   npx eslint .
+   ```
 
 ## Available Scripts
 


### PR DESCRIPTION
## Summary
- remind devs to run prettier and eslint before committing

## Testing
- `npx prettier --write .`
- `npx eslint .` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test` *(fails: react-scripts not found)*