### PR TITLE
Update ESLint config

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,5 +5,6 @@ import { fileURLToPath } from "url";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const configPath = path.join(__dirname, ".eslintrc.json");
 const config = JSON.parse(fs.readFileSync(configPath, "utf8"));
+delete config.extends; // remove unsupported key in flat config
 
-export default config;
+export default [config]; // ESLint 9 expects an array


### PR DESCRIPTION
## Summary
- export eslint config as an array for ESLint 9
- strip unsupported `extends` entry from the config

## Testing
- `npx prettier --check .`
- `npx eslint .` *(fails: Parsing error: Unexpected token <)*
- `npm test` *(fails: react-scripts not found)*