### PR TITLE
Improve font loading and CSP

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        style-src 'self' 'unsafe-inline' https://fonts.googleapis.com;
+        style-src 'self' https://fonts.googleapis.com;
         font-src 'self' https://fonts.gstatic.com;
         img-src 'self' data:;
         script-src 'self';
@@ -22,9 +22,17 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
+      rel="preload"
       href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap"
-      rel="stylesheet"
+      as="style"
+      onload="this.rel='stylesheet'"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css?family=Roboto:400,700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
     <link rel="canonical" href="https://oriolmacias.dev" />
   </head>
 


### PR DESCRIPTION
## Summary
- preload Roboto stylesheet and load it asynchronously
- remove `'unsafe-inline'` since no inline styles exist

## Testing
- `npx prettier --write public/index.html`
- `npx prettier --write .`
- `npx eslint .` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test --silent` *(fails: react-scripts not found)*
- `npx prettier --check .`
- `npx eslint .` *(fails: A config object is using the "extends" key, which is not supported in flat config system)*
- `npm test --silent` *(fails: react-scripts not found)*