### PR TITLE
Fix skills chart height

### DIFF
--- a/src/styles/components/Skills.scss
+++ b/src/styles/components/Skills.scss
@@ -11,6 +11,7 @@
   }
   &__chart {
     margin-bottom: 40px;
+    min-height: 500px;
   }
 
   &__categories {


### PR DESCRIPTION
## Summary
- add `min-height` to the skills chart
- keep chart height in `Skills.jsx` at 500

## Testing
- `npx prettier --write src/components/Skills.jsx src/styles/components/Skills.scss`
- `npx eslint src/components/Skills.jsx src/styles/components/Skills.scss`
- `npm test --silent` *(fails: react-scripts not found)*