### PR TITLE
Add additional asset caching

### DIFF
--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -31,6 +31,33 @@ registerRoute(
     url.origin === self.location.origin && url.pathname.endsWith(".png"),
   new StaleWhileRevalidate({
     cacheName: "images",
+    plugins: [new ExpirationPlugin({ maxEntries: 100 })],
+  }),
+);
+
+registerRoute(
+  ({ url }) =>
+    url.origin === self.location.origin && url.pathname.endsWith(".webp"),
+  new StaleWhileRevalidate({
+    cacheName: "images",
+    plugins: [new ExpirationPlugin({ maxEntries: 100 })],
+  }),
+);
+
+registerRoute(
+  ({ url }) =>
+    url.origin === self.location.origin && url.pathname.endsWith(".css"),
+  new StaleWhileRevalidate({
+    cacheName: "styles",
+    plugins: [new ExpirationPlugin({ maxEntries: 50 })],
+  }),
+);
+
+registerRoute(
+  ({ url }) =>
+    url.origin === self.location.origin && url.pathname.endsWith(".woff2"),
+  new StaleWhileRevalidate({
+    cacheName: "fonts",
     plugins: [new ExpirationPlugin({ maxEntries: 50 })],
   }),
 );


### PR DESCRIPTION
## Summary
- extend Workbox service worker cache to css, webp and font files
- increase cache capacity for images

## Testing
- `npx prettier --check .`
- `npx eslint .` *(fails: `extends` not supported in flat config)*
- `npm test` *(fails: react-scripts not found)*
- `npm run build-sw` *(fails: cannot find module 'workbox-build')*