### PR TITLE
Add cache headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,13 @@ This section has moved here: [https://facebook.github.io/create-react-app/docs/d
 ### `npm run build` fails to minify
 
 This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)
+
+## Cache-Control headers
+
+El archivo `public/_headers` define cabeceras para servir recursos estáticos con caché prolongada. Las imágenes, fuentes, archivos CSS y JS se entregan con:
+
+```text
+Cache-Control: public, max-age=31536000, immutable
+```
+
+Estas reglas ayudan a que los activos versionados se mantengan en el navegador durante un año. El `service-worker.js` tiene una regla aparte con `no-cache` para asegurar que las actualizaciones se apliquen correctamente.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,44 @@
+/static/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.js
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.css
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.png
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.jpeg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.gif
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.svg
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.webp
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ico
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.woff2
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.ttf
+  Cache-Control: public, max-age=31536000, immutable
+
+/*.eot
+  Cache-Control: public, max-age=31536000, immutable
+
+/service-worker.js
+  Cache-Control: no-cache


### PR DESCRIPTION
## Summary
- add `public/_headers` for long term caching of static assets
- document the header configuration in the README

## Testing
- `npx prettier --check .`
- `npx eslint .` *(fails: A config object is using the "extends" key)*
- `npm test` *(fails: react-scripts not found)*