### PR TITLE
Add explicit image dimensions, tweak ESLint

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,13 @@
-export default [];
+export default [
+  {
+    languageOptions: {
+      parserOptions: {
+        ecmaVersion: "latest",
+        sourceType: "module",
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+  },
+];

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -22,7 +22,13 @@ const Introduction = () => {
     <section id="introduction" className="introduction">
       <div className="introduction__content">
         <div className="introduction__photo">
-          <img src={photo} alt={t("introduction.altText")} loading="lazy" />
+          <img
+            src={photo}
+            alt={t("introduction.altText")}
+            width="250"
+            height="250"
+            fetchpriority="high"
+          />
         </div>
         <div className="introduction__text">
           <h2 className="introduction__title">{t("introduction.title")}</h2>

--- a/src/components/Languages.jsx
+++ b/src/components/Languages.jsx
@@ -25,7 +25,13 @@ const Languages = () => {
       <div className="language-list">
         {languages.map((lang, idx) => (
           <div key={idx} className="language-item">
-            <img src={flagImages[lang.code]} alt={lang.name} loading="lazy" />
+            <img
+              src={flagImages[lang.code]}
+              alt={lang.name}
+              loading="lazy"
+              width="80"
+              height="60"
+            />
             <div className="language-info">
               <h4>{lang.name}</h4>
               <p>

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
@@ -73,5 +72,3 @@ self.addEventListener("message", (event) => {
     self.skipWaiting();
   }
 });
-
-/* eslint-enable no-restricted-globals */


### PR DESCRIPTION
## Summary
- add intrinsic image size to introduction photo
- set flag dimensions in Languages component
- allow JSX parsing in ESLint config
- drop unused directive from service worker

## Testing
- `npx prettier --write .`
- `npx eslint .`
- `npm test --silent` *(fails: react-scripts not found)*