### PR TITLE
Implement lazy loading for intro animation

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,0 @@
-export default [];

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -1,22 +1,27 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import Lottie from "lottie-react";
 import "../styles/components/Introduction.scss";
 import photo from "../assets/images/photo.webp";
+import useIntersectionObserver from "../hooks/useIntersectionObserver";
 
 const Introduction = () => {
   const { t } = useTranslation();
   const [animationData, setAnimationData] = useState(null);
+  const animationRef = useRef(null);
+  const isVisible = useIntersectionObserver(animationRef, { threshold: 0.1 });
 
   useEffect(() => {
-    import("../assets/animations/introAnimation.min.json")
-      .then((module) => {
-        setAnimationData(module.default);
-      })
-      .catch((err) => {
-        console.error("Error loading animation", err);
-      });
-  }, []);
+    if (isVisible && !animationData) {
+      import("../assets/animations/introAnimation.min.json")
+        .then((module) => {
+          setAnimationData(module.default);
+        })
+        .catch((err) => {
+          console.error("Error loading animation", err);
+        });
+    }
+  }, [isVisible, animationData]);
 
   return (
     <section id="introduction" className="introduction">
@@ -34,6 +39,7 @@ const Introduction = () => {
           </p>
         </div>
         <div
+          ref={animationRef}
           className="introduction__animation"
           aria-label={t("introduction.animationAltText")}
         >

--- a/src/hooks/useIntersectionObserver.js
+++ b/src/hooks/useIntersectionObserver.js
@@ -1,0 +1,24 @@
+import { useState, useEffect } from "react";
+
+const useIntersectionObserver = (ref, options) => {
+  const [isIntersecting, setIsIntersecting] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setIsIntersecting(true);
+        observer.disconnect();
+      }
+    }, options);
+
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, [ref, options]);
+
+  return isIntersecting;
+};
+
+export default useIntersectionObserver;


### PR DESCRIPTION
## Summary
- remove unused eslint.config.js
- add `useIntersectionObserver` custom hook
- lazy load intro animation when visible

## Testing
- `npx prettier --write src/hooks/useIntersectionObserver.js src/components/Introduction.jsx`
- `npx eslint .` *(fails: ESLint config requires packages not installed)*
- `npm test` *(fails: react-scripts not found)*