### PR TITLE
Improve ESLint config and clean service worker

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,11 @@
-export default [];
+export default [
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: 2020,
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    rules: {},
+  },
+];

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
@@ -73,5 +72,3 @@ self.addEventListener("message", (event) => {
     self.skipWaiting();
   }
 });
-
-/* eslint-enable no-restricted-globals */


### PR DESCRIPTION
## Summary
- configure ESLint parser so linting can run
- remove obsolete eslint directives from `service-worker.js`

## Testing
- `npx prettier --check .`
- `npx eslint .`
- `npm test --silent` *(fails: react-scripts not found)*