### PR TITLE
Add ErrorBoundary component

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,12 @@
-export default [];
+export default [
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      globals: { document: "readonly", window: "readonly" },
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+    rules: {},
+  },
+];

--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,27 @@
+import React from "react";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    // Log error details for debugging
+    console.error("ErrorBoundary caught an error", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <h1>Something went wrong.</h1>;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/ErrorBoundary.test.js
+++ b/src/components/ErrorBoundary.test.js
@@ -1,0 +1,17 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import ErrorBoundary from "./ErrorBoundary";
+
+function ProblemChild() {
+  throw new Error("Error!");
+}
+
+test("renders fallback UI on error", () => {
+  jest.spyOn(console, "error").mockImplementation(() => {});
+  render(
+    <ErrorBoundary>
+      <ProblemChild />
+    </ErrorBoundary>,
+  );
+  expect(screen.getByText(/something went wrong/i)).toBeInTheDocument();
+});

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ import { createRoot } from "react-dom/client";
 import App from "./App";
 import { I18nextProvider } from "react-i18next";
 import { ThemeProvider } from "./contexts/ThemeContext";
+import ErrorBoundary from "./components/ErrorBoundary";
 import i18n from "./i18n";
 import * as serviceWorkerRegistration from "./serviceWorkerRegistration";
 import { BrowserRouter } from "react-router-dom";
@@ -20,7 +21,9 @@ root.render(
     <BrowserRouter>
       <I18nextProvider i18n={i18n}>
         <ThemeProvider>
-          <App />
+          <ErrorBoundary>
+            <App />
+          </ErrorBoundary>
         </ThemeProvider>
       </I18nextProvider>
     </BrowserRouter>

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
@@ -74,4 +73,3 @@ self.addEventListener("message", (event) => {
   }
 });
 
-/* eslint-enable no-restricted-globals */


### PR DESCRIPTION
## Summary
- implement `ErrorBoundary` component
- use `ErrorBoundary` around `App`
- add tests for the new error boundary
- simplify ESLint config and remove unused comments

## Testing
- `npx prettier --write .`
- `npx eslint .`
- `npm test --silent` *(fails: react-scripts not found)*