### PR TITLE
Add dynamic preload for CSS and hero image

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,13 @@
-export default [];
+export default [
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+      },
+    },
+    rules: {},
+  },
+];

--- a/public/index.html
+++ b/public/index.html
@@ -34,6 +34,32 @@
       />
     </noscript>
     <link rel="canonical" href="https://oriolmacias.dev" />
+    <script>
+      fetch("%PUBLIC_URL%/asset-manifest.json")
+        .then((r) => r.json())
+        .then((m) => {
+          const files = m.files || {};
+          const head = document.head;
+          if (files["main.css"]) {
+            const linkCss = document.createElement("link");
+            linkCss.rel = "preload";
+            linkCss.href = files["main.css"];
+            linkCss.as = "style";
+            head.appendChild(linkCss);
+          }
+          const photoKey = Object.keys(files).find((k) =>
+            k.endsWith("photo.webp"),
+          );
+          if (photoKey) {
+            const linkImg = document.createElement("link");
+            linkImg.rel = "preload";
+            linkImg.href = files[photoKey];
+            linkImg.as = "image";
+            head.appendChild(linkImg);
+          }
+        })
+        .catch((e) => console.error("preload", e));
+    </script>
   </head>
 
   <body>

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
@@ -73,5 +72,3 @@ self.addEventListener("message", (event) => {
     self.skipWaiting();
   }
 });
-
-/* eslint-enable no-restricted-globals */

--- a/src/sw-build.js
+++ b/src/sw-build.js
@@ -6,7 +6,7 @@ const buildSW = () => {
       swSrc: "src/service-worker.js",
       swDest: "build/cv/service-worker.js",
       globDirectory: "build",
-      globPatterns: ["**/*.{js,css,html,png,jpg,json}"],
+      globPatterns: ["**/*.{js,css,html,png,jpg,webp,json}"],
     })
     .then(({ count, size, warnings }) => {
       warnings.forEach(console.warn);


### PR DESCRIPTION
## Summary
- dynamically preload main CSS and hero image using asset-manifest.json
- include webp files in service worker build
- clean up service worker lint directives
- configure ESLint parser to understand JSX

## Testing
- `npx prettier --check .`
- `npx eslint .`
- `npx react-scripts test --watchAll=false` *(fails: connect EHOSTUNREACH)*