### PR TITLE
Implement PDF retry and tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,1 +1,10 @@
-export default [];
+export default [
+  {
+    files: ["**/*.{js,jsx}"],
+    languageOptions: {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      parserOptions: { ecmaFeatures: { jsx: true } },
+    },
+  },
+];

--- a/src/components/PDFModal.jsx
+++ b/src/components/PDFModal.jsx
@@ -7,11 +7,17 @@ Modal.setAppElement("#root");
 
 const PDFModal = ({ isOpen, onRequestClose }) => {
   const [pdfError, setPdfError] = useState(false);
+  const [retryKey, setRetryKey] = useState(0);
   const pdfUrl = "/OriolMaciasBadosa_CV.pdf";
   const { t } = useTranslation();
 
   const handlePdfError = () => {
     setPdfError(true);
+  };
+
+  const handleRetry = () => {
+    setPdfError(false);
+    setRetryKey((prev) => prev + 1);
   };
 
   return (
@@ -27,9 +33,13 @@ const PDFModal = ({ isOpen, onRequestClose }) => {
           &times;
         </button>
         {pdfError ? (
-          <p>{t("pdfModal.errorLoading")}</p>
+          <div>
+            <p>{t("pdfModal.errorLoading")}</p>
+            <button onClick={handleRetry}>{t("pdfModal.retry")}</button>
+          </div>
         ) : (
           <iframe
+            key={retryKey}
             src={pdfUrl}
             title={t("pdfModal.title")}
             width="100%"

--- a/src/components/PDFModal.test.js
+++ b/src/components/PDFModal.test.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { I18nextProvider } from "react-i18next";
+import i18n from "../i18n";
+import PDFModal from "./PDFModal";
+
+describe("PDFModal", () => {
+  test("shows error message and retry button on load error", () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PDFModal isOpen onRequestClose={() => {}} />
+      </I18nextProvider>,
+    );
+
+    const iframe = screen.getByTitle(i18n.t("pdfModal.title"));
+    fireEvent.error(iframe);
+
+    expect(
+      screen.getByText(i18n.t("pdfModal.errorLoading")),
+    ).toBeInTheDocument();
+    expect(screen.getByText(i18n.t("pdfModal.retry"))).toBeInTheDocument();
+  });
+
+  test("retries loading when retry button clicked", () => {
+    render(
+      <I18nextProvider i18n={i18n}>
+        <PDFModal isOpen onRequestClose={() => {}} />
+      </I18nextProvider>,
+    );
+
+    const iframe = screen.getByTitle(i18n.t("pdfModal.title"));
+    fireEvent.error(iframe);
+
+    const retryButton = screen.getByText(i18n.t("pdfModal.retry"));
+    fireEvent.click(retryButton);
+
+    expect(
+      screen.queryByText(i18n.t("pdfModal.errorLoading")),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTitle(i18n.t("pdfModal.title"))).toBeInTheDocument();
+  });
+});

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -169,7 +169,8 @@
   },
   "pdfModal": {
     "title": "Lebenslauf PDF",
-    "errorLoading": "Fehler beim Laden des PDFs. Bitte versuchen Sie es später erneut."
+    "errorLoading": "Fehler beim Laden des PDFs. Bitte versuchen Sie es später erneut.",
+    "retry": "Erneut versuchen"
   },
   "common": {
     "loading": "Wird geladen..."

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -170,7 +170,8 @@
   },
   "pdfModal": {
     "title": "CV PDF",
-    "errorLoading": "Error loading PDF. Please try again later."
+    "errorLoading": "Error loading PDF. Please try again later.",
+    "retry": "Retry"
   },
   "common": {
     "loading": "Loading..."

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -170,7 +170,8 @@
   },
   "pdfModal": {
     "title": "CV en PDF",
-    "errorLoading": "Error al cargar el PDF. Por favor, inténtelo de nuevo más tarde."
+    "errorLoading": "Error al cargar el PDF. Por favor, inténtelo de nuevo más tarde.",
+    "retry": "Reintentar"
   },
   "common": {
     "loading": "Cargando..."

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -169,7 +169,8 @@
   },
   "pdfModal": {
     "title": "CV PDF",
-    "errorLoading": "Erreur de chargement du PDF. Veuillez réessayer plus tard."
+    "errorLoading": "Erreur de chargement du PDF. Veuillez réessayer plus tard.",
+    "retry": "Réessayer"
   },
   "common": {
     "loading": "Chargement..."

--- a/src/locales/it/translation.json
+++ b/src/locales/it/translation.json
@@ -169,7 +169,8 @@
   },
   "pdfModal": {
     "title": "CV PDF",
-    "errorLoading": "Errore nel caricamento del PDF. Si prega di riprovare più tardi."
+    "errorLoading": "Errore nel caricamento del PDF. Si prega di riprovare più tardi.",
+    "retry": "Riprova"
   },
   "common": {
     "loading": "Caricamento in corso..."

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-restricted-globals */
 import { clientsClaim } from "workbox-core";
 import { ExpirationPlugin } from "workbox-expiration";
 import { precacheAndRoute, createHandlerBoundToURL } from "workbox-precaching";
@@ -73,5 +72,3 @@ self.addEventListener("message", (event) => {
     self.skipWaiting();
   }
 });
-
-/* eslint-enable no-restricted-globals */


### PR DESCRIPTION
## Summary
- add JSX parser config so ESLint runs
- show retry button on PDF load error
- implement retry mechanism for the PDF iframe
- localize retry label
- drop unused eslint-disable from service worker
- test PDF error and retry behaviour

## Testing
- `npx prettier --check .`
- `npx eslint .`
- `npm test --silent` *(fails: react-scripts not found)*